### PR TITLE
Add signed audit log, RBAC and rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # nnm_website
+
+Herramientas básicas para gestión de usuarios y seguridad.
+
+## Características
+- Registro de auditoría firmado y exportable (JSON o CSV).
+- Control de acceso basado en roles (owner, admin, soporte, user).
+- Rate limiting y protección CSRF en formularios.
+
+## Pruebas
+```
+php -d assert.exception=1 tests/security_test.php
+```
+

--- a/audit_export.php
+++ b/audit_export.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/init.php';
+require_once __DIR__.'/helpers.php';
+
+$format = $_GET['format'] ?? 'json';
+$st = db()->query('SELECT user_id, action, meta, signature, created_at FROM audit_logs ORDER BY id ASC');
+$rows = $st->fetchAll();
+
+if ($format === 'csv') {
+  header('Content-Type: text/csv');
+  header('Content-Disposition: attachment; filename="audit.csv"');
+  $out = fopen('php://output', 'w');
+  fputcsv($out, ['user_id','action','meta','signature','created_at']);
+  foreach ($rows as $r) {
+    fputcsv($out, [$r['user_id'], $r['action'], $r['meta'], $r['signature'], $r['created_at']]);
+  }
+  fclose($out);
+} else {
+  header('Content-Type: application/json');
+  echo json_encode($rows, JSON_UNESCAPED_UNICODE);
+}
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'user'
+);
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  meta TEXT,
+  signature TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE TRIGGER IF NOT EXISTS audit_logs_immutable
+BEFORE UPDATE ON audit_logs BEGIN
+  SELECT RAISE(ABORT, 'audit logs are append only');
+END;
+CREATE TRIGGER IF NOT EXISTS audit_logs_no_delete
+BEFORE DELETE ON audit_logs BEGIN
+  SELECT RAISE(ABORT, 'audit logs are append only');
+END;
+
+CREATE TABLE IF NOT EXISTS rate_limits (
+  key TEXT PRIMARY KEY,
+  tokens INTEGER NOT NULL,
+  reset_at INTEGER NOT NULL
+);

--- a/migrate.php
+++ b/migrate.php
@@ -44,7 +44,23 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
   action TEXT NOT NULL,                  -- 'login'|'enable_vpn'|'disable_vpn'...
   meta TEXT,                             -- JSON ligero
+  signature TEXT NOT NULL,
   created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE TRIGGER IF NOT EXISTS audit_logs_immutable
+  BEFORE UPDATE ON audit_logs BEGIN
+    SELECT RAISE(ABORT, 'audit logs are append only');
+  END;
+CREATE TRIGGER IF NOT EXISTS audit_logs_no_delete
+  BEFORE DELETE ON audit_logs BEGIN
+    SELECT RAISE(ABORT, 'audit logs are append only');
+  END;
+
+CREATE TABLE IF NOT EXISTS rate_limits (
+  key TEXT PRIMARY KEY,
+  tokens INTEGER NOT NULL,
+  reset_at INTEGER NOT NULL
 );
 SQL);
 

--- a/tests/security_test.php
+++ b/tests/security_test.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../init.php';
+require_once __DIR__.'/../helpers.php';
+
+// insert test user
+$db = db();
+$db->exec("INSERT INTO users (username, role) VALUES ('tester', 'admin')");
+$u = $db->query("SELECT * FROM users WHERE username='tester'")->fetch();
+
+assert(user_has_role($u, 'admin') === true);
+assert(user_has_role($u, 'user') === false);
+require_role($u, 'admin');
+
+// audit logging
+audit((int)$u['id'], 'test', ['ok'=>1]);
+$log = $db->query('SELECT * FROM audit_logs')->fetch();
+assert($log['action'] === 'test');
+assert(strlen($log['signature']) === 64);
+
+// rate limiting
+assert(rate_limit('login', 2, 60) === true);
+assert(rate_limit('login', 2, 60) === true);
+assert(rate_limit('login', 2, 60) === false);
+
+echo "OK\n";
+

--- a/variables.php
+++ b/variables.php
@@ -16,4 +16,7 @@ return [
 
   // Paths
   'DATA_DIR' => '/var/nnm',
+  // Audit
+  'AUDIT_SECRET' => getenv('AUDIT_SECRET') ?: 'dev-secret',
 ];
+


### PR DESCRIPTION
## Summary
- implement signed audit log with HMAC and export endpoint
- add role-based access control helpers and basic rate limiting
- include schema and tests for audit log, RBAC and rate limit

## Testing
- `php -l helpers.php`
- `php -l audit_export.php`
- `php -l variables.php`
- `php -l migrate.php`
- `php -l tests/security_test.php`
- `php -d assert.exception=1 tests/security_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad765ba01c8333ba79eaf92c0841df