### PR TITLE
Add transactional email templates and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Herramientas básicas para gestión de usuarios y seguridad.
 php -d assert.exception=1 tests/security_test.php
 ```
 
+
+## Correo transaccional
+- Plantillas HTML en `templates/{es,en}/<tipo>.html`.
+- Configuración via variables de entorno: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `MAIL_FROM`.
+- Los envíos se registran en la tabla `mail_logs` para garantizar idempotencia y métricas.
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -27,3 +27,14 @@ CREATE TABLE IF NOT EXISTS rate_limits (
   tokens INTEGER NOT NULL,
   reset_at INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS mail_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  message_id TEXT NOT NULL UNIQUE,
+  type TEXT NOT NULL,
+  recipient TEXT NOT NULL,
+  status TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  sent_at TEXT
+);

--- a/mail.php
+++ b/mail.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Simple transactional mailer with template rendering and idempotent logging.
+ * In production, replace the stub sending logic with an SMTP library
+ * such as PHPMailer to honour SMTP_* environment variables.
+ */
+function send_mail(string $type, string $to, array $vars = [], string $lang = 'es'): bool {
+    $messageId = $vars['message_id'] ?? sha1($type.'|'.$to.'|'.json_encode($vars));
+    $db = db();
+    $st = $db->prepare('SELECT status, attempts FROM mail_logs WHERE message_id=?');
+    $st->execute([$messageId]);
+    $row = $st->fetch();
+    if ($row && $row['status'] === 'sent') {
+        return true; // idempotent: already sent
+    }
+    $template = __DIR__."/templates/{$lang}/{$type}.html";
+    if (!is_file($template)) {
+        throw new RuntimeException('template not found');
+    }
+    $body = file_get_contents($template);
+    foreach ($vars as $k => $v) {
+        if (is_scalar($v)) {
+            $body = str_replace('{{'.$k.'}}', htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'), $body);
+        }
+    }
+    $mailFrom = getenv('MAIL_FROM') ?: 'NNM Secure <info@northnexusmex.cloud>';
+    $smtpHost = getenv('SMTP_HOST') ?: '';
+    $smtpPort = getenv('SMTP_PORT') ?: '';
+    $smtpUser = getenv('SMTP_USER') ?: '';
+    $smtpPass = getenv('SMTP_PASS') ?: '';
+    $subject = $vars['subject'] ?? 'NNM';
+
+    // Stub send: replace with real SMTP implementation.
+    $sent = true;
+
+    $attempts = $row ? ((int)$row['attempts'] + 1) : 1;
+    $status = $sent ? 'sent' : 'failed';
+    $lastError = $sent ? null : 'send failed';
+    $sentAt = $sent ? gmdate('Y-m-d\TH:i:s\Z') : null;
+    $st = $db->prepare('REPLACE INTO mail_logs(message_id,type,recipient,status,attempts,last_error,sent_at) VALUES(?,?,?,?,?,?,?)');
+    $st->execute([$messageId,$type,$to,$status,$attempts,$lastError,$sentAt]);
+    return $sent;
+}

--- a/migrate.php
+++ b/migrate.php
@@ -62,6 +62,17 @@ CREATE TABLE IF NOT EXISTS rate_limits (
   tokens INTEGER NOT NULL,
   reset_at INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS mail_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  message_id TEXT NOT NULL UNIQUE,
+  type TEXT NOT NULL,
+  recipient TEXT NOT NULL,
+  status TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  sent_at TEXT
+);
 SQL);
 
 echo "OK\n";

--- a/register.php
+++ b/register.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__.'/init.php';
+require_once __DIR__.'/mail.php';
 require_once __DIR__.'/helpers.php';
 
 $error = '';
@@ -15,6 +16,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
       $st = db()->prepare('INSERT INTO users(email, pass_hash) VALUES(?,?)');
       $st->execute([$email,$hash]);
+      send_mail('welcome', $email, ['name'=>$email, 'subject'=>'Bienvenido a NNM Secure']);
       $_SESSION['uid'] = (int)db()->lastInsertId();
       header('Location: /panel.php');
       exit;

--- a/templates/en/billing.html
+++ b/templates/en/billing.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, your payment has been processed. Invoice: {{invoice}}</p>

--- a/templates/en/confirm.html
+++ b/templates/en/confirm.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, confirm your email at this link: {{link}}</p>

--- a/templates/en/reset.html
+++ b/templates/en/reset.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, reset your password here: {{link}}</p>

--- a/templates/en/seafile.html
+++ b/templates/en/seafile.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, your Seafile account has been created. Access: {{link}}</p>

--- a/templates/en/vaultwarden.html
+++ b/templates/en/vaultwarden.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, your Vaultwarden invitation: {{link}}</p>

--- a/templates/en/welcome.html
+++ b/templates/en/welcome.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, welcome to NNM Secure.</p>

--- a/templates/en/wireguard.html
+++ b/templates/en/wireguard.html
@@ -1,0 +1,1 @@
+<p>Hello {{name}}, your WireGuard configuration is attached.</p>

--- a/templates/es/billing.html
+++ b/templates/es/billing.html
@@ -1,0 +1,1 @@
+<p>Hola {{name}}, se ha procesado tu pago. Factura: {{invoice}}</p>

--- a/templates/es/confirm.html
+++ b/templates/es/confirm.html
@@ -1,0 +1,1 @@
+<p>Hola {{name}}, confirma tu email en este enlace: {{link}}</p>

--- a/templates/es/reset.html
+++ b/templates/es/reset.html
@@ -1,0 +1,1 @@
+<p>Hola {{name}}, restablece tu contraseña aquí: {{link}}</p>

--- a/templates/es/seafile.html
+++ b/templates/es/seafile.html
@@ -1,0 +1,1 @@
+<p>Hola {{name}}, tu cuenta Seafile ha sido creada. Accede: {{link}}</p>

--- a/templates/es/vaultwarden.html
+++ b/templates/es/vaultwarden.html
@@ -1,0 +1,1 @@
+<p>Hola {{name}}, tu invitación a Vaultwarden: {{link}}</p>

--- a/templates/es/welcome.html
+++ b/templates/es/welcome.html
@@ -1,0 +1,1 @@
+<p>Hola {{name}}, bienvenido a NNM Secure.</p>

--- a/templates/es/wireguard.html
+++ b/templates/es/wireguard.html
@@ -1,0 +1,1 @@
+<p>Hola {{name}}, adjuntamos tu configuración WireGuard.</p>

--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__.'/../init.php';
+require_once __DIR__.'/../mail.php';
+
+$messageId = bin2hex(random_bytes(4));
+assert(send_mail('welcome', 'test@example.com', ['name'=>'Tester','message_id'=>$messageId]) === true);
+$st = db()->prepare('SELECT * FROM mail_logs WHERE message_id=?');
+$st->execute([$messageId]);
+$log = $st->fetch();
+assert($log['status'] === 'sent');
+assert((int)$log['attempts'] === 1);
+// second call should not create new attempt
+assert(send_mail('welcome', 'test@example.com', ['name'=>'Tester','message_id'=>$messageId]) === true);
+$st->execute([$messageId]);
+$log2 = $st->fetch();
+assert((int)$log2['attempts'] === 1);
+
+echo "OK\n";


### PR DESCRIPTION
## Summary
- add bilingual HTML templates and mailer stub with idempotent logging
- record email sends in new `mail_logs` table and send welcome email on registration
- document SMTP env vars and cover mailer with tests

## Testing
- `php -d assert.exception=1 tests/security_test.php`
- `php -d assert.exception=1 tests/mail_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad796b04b0833395f8a0b0a79354c8