### PR TITLE
Refactor security test and streamline site styles

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -33,13 +33,14 @@ function require_role(array $u, string ...$roles): void {
   }
 }
 
-function audit(int $uid, string $action, array $payload = []): void {
+function audit(int $uid, string $action, array $payload = []): int {
   global $CONFIG;
   $meta = json_encode($payload, JSON_UNESCAPED_UNICODE);
   $ts = time();
   $sig = hash_hmac('sha256', $uid . '|' . $action . '|' . $meta . '|' . $ts, $CONFIG['AUDIT_SECRET']);
   $st = db()->prepare('INSERT INTO audit_logs(user_id,action,meta,signature,created_at) VALUES(?,?,?,?,datetime("now"))');
   $st->execute([$uid, $action, $meta, $sig]);
+  return (int)db()->lastInsertId();
 }
 
 function rate_limit(string $key, int $limit, int $period): bool {

--- a/index.php
+++ b/index.php
@@ -15,10 +15,10 @@ include __DIR__.'/partials/head.php';
       <div class="col-md-6 text-md-start">
         <h1 class="display-5 fw-bold" data-i18n="hero.title">Privacidad simple. Rendimiento constante.</h1>
         <p class="lead" data-i18n="hero.subtitle">VPN WireGuard, Bitwarden autoalojado y nube cifrada con servidores en Reino Unido y Alemania.</p>
-        <div class="d-flex gap-2 justify-content-center justify-content-md-start">
+        <div class="d-flex gap-2 justify-content-center justify-content-md-start align-items-center">
           <button class="btn btn-primary" onclick="document.querySelector('#services').scrollIntoView({behavior:'smooth'})" data-i18n="hero.cta_primary">Ver servicios</button>
           <button class="btn btn-outline-light" onclick="document.querySelector('#pricing').scrollIntoView({behavior:'smooth'})" data-i18n="hero.cta_secondary">Ver precios</button>
-          <span class="px-2 py-1 text-sm rounded bg-gray-100 text-gray-900 self-center">Desde <span class="price price-badge" data-price="PRICE_VPN"></span><span class="unit"></span> / mes</span>
+          <span class="badge bg-light text-dark">Desde <span class="price price-badge" data-price="PRICE_VPN"></span><span class="unit"></span> / mes</span>
         </div>
         <div class="d-flex gap-2 mt-3">
           <i class="bi bi-shield-lock"></i><strong>&nbsp;Cifrado serio</strong>
@@ -32,7 +32,7 @@ include __DIR__.'/partials/head.php';
         </div>
       </div>
       <div class="col-md-6 mt-4 mt-md-0">
-        <div class="card text-body shadow">
+        <div class="card shadow">
           <div class="card-body">
             <div class="d-flex justify-content-between">
               <strong>Estado</strong><span class="text-muted">Infra UE</span>
@@ -78,7 +78,7 @@ include __DIR__.'/partials/head.php';
             <img class="service-logo logo-dark" src="static/rsc/nnm-vpn-logo.png" alt="VPN">
             <div class="d-flex justify-content-between">
               <strong data-i18n="sections.services.card_vpn.title">VPN</strong>
-              <span class="px-2 py-1 text-xs rounded bg-gray-600 text-white"><span class="price" data-price="PRICE_VPN"></span><span class="unit"></span> /m</span>
+              <span class="badge bg-secondary"><span class="price" data-price="PRICE_VPN"></span><span class="unit"></span> /m</span>
             </div>
             <ul class="text-muted">
               <li data-i18n="sections.services.card_vpn.p1">WireGuard por defecto.</li>
@@ -93,7 +93,7 @@ include __DIR__.'/partials/head.php';
             <img class="service-logo logo-dark" src="static/rsc/nnm-psw-logo.png" alt="Gestor">
             <div class="d-flex justify-content-between">
               <strong data-i18n="sections.services.card_password_manager.title">Gestor de contraseñas</strong>
-              <span class="px-2 py-1 text-xs rounded bg-gray-600 text-white"><span class="price" data-price="PRICE_PASSWORD"></span><span class="unit"></span> /m</span>
+              <span class="badge bg-secondary"><span class="price" data-price="PRICE_PASSWORD"></span><span class="unit"></span> /m</span>
             </div>
             <ul class="text-muted">
               <li data-i18n="sections.services.card_password_manager.p1">Cifrado E2E.</li>
@@ -108,7 +108,7 @@ include __DIR__.'/partials/head.php';
             <img class="service-logo logo-dark" src="static/rsc/nnm-stg-logo.png" alt="Storage">
             <div class="d-flex justify-content-between">
               <strong data-i18n="sections.services.card_encrypted_storage.title">Almacenamiento cifrado</strong>
-              <span class="px-2 py-1 text-xs rounded bg-gray-600 text-white"><span class="price" data-price="PRICE_STORAGE"></span><span class="unit"></span> /m</span>
+              <span class="badge bg-secondary"><span class="price" data-price="PRICE_STORAGE"></span><span class="unit"></span> /m</span>
             </div>
             <ul class="text-muted">
               <li data-i18n="sections.services.card_encrypted_storage.p1">Versionado y enlaces protegidos.</li>

--- a/partials/head.php
+++ b/partials/head.php
@@ -21,7 +21,6 @@ $canonical = $canonical ?? ('https://' . $host . ($_SERVER['REQUEST_URI'] ?? '/'
   <meta name="color-scheme" content="light dark">
   <link rel="icon" href="/static/rsc/nnm-logo.ico">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/static/css/styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 </head>

--- a/partials/nav.php
+++ b/partials/nav.php
@@ -1,45 +1,46 @@
 <?php $isLogged = !empty($_SESSION['uid']); ?>
-<nav class="bg-white dark:bg-gray-900 shadow-sm">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-    <a class="flex items-center gap-2 font-semibold text-indigo-600 dark:text-indigo-400" href="/">
-      <img src="/static/rsc/nnm-logo.png" alt="NNM" class="w-7 h-7 logo-dark">
+<nav class="shadow-sm">
+  <div class="navbar container">
+    <a class="navbar-brand" href="/">
+      <img src="/static/rsc/nnm-logo.png" alt="NNM" class="logo-dark">
       <span data-i18n="brand">NNM Secure</span>
     </a>
-    <button class="md:hidden text-2xl" id="navToggle" aria-label="Menú">
+    <button class="navbar-toggler" id="navToggle" aria-label="Menú">
       <i class="bi bi-list"></i>
     </button>
-    <div class="hidden flex flex-col md:flex md:flex-row md:items-center md:space-x-6" id="mainNav">
-      <ul class="flex flex-col md:flex-row md:space-x-4">
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#services" data-i18n="nav.services">Servicios</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#features" data-i18n="nav.features">Características</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#pricing" data-i18n="nav.pricing">Precios</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#faq" data-i18n="nav.faq">FAQ</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#contact" data-i18n="nav.contact">Contacto</a></li>
+    <div class="navbar-menu" id="mainNav">
+      <ul class="navbar-nav">
+        <li><a class="nav-link" href="/#services" data-i18n="nav.services">Servicios</a></li>
+        <li><a class="nav-link" href="/#features" data-i18n="nav.features">Características</a></li>
+        <li><a class="nav-link" href="/#pricing" data-i18n="nav.pricing">Precios</a></li>
+        <li><a class="nav-link" href="/#faq" data-i18n="nav.faq">FAQ</a></li>
+        <li><a class="nav-link" href="/#contact" data-i18n="nav.contact">Contacto</a></li>
       </ul>
-      <div class="flex items-center space-x-2 mt-2 md:mt-0">
-        <div class="relative dropdown">
-          <button class="dropdown-toggle flex items-center gap-1 px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" id="btnLang"><i class="bi bi-translate"></i> <span id="lblLang">ES</span></button>
-          <ul class="dropdown-menu absolute right-0 mt-1 hidden bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-md" id="menuLang">
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-lang="es" href="#">Español</a></li>
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-lang="en" href="#">English</a></li>
+      <div class="nav-actions">
+        <div class="dropdown">
+          <button class="dropdown-toggle btn btn-outline-primary" id="btnLang"><i class="bi bi-translate"></i> <span id="lblLang">ES</span></button>
+          <ul class="dropdown-menu" id="menuLang">
+            <li><a data-lang="es" href="#">Español</a></li>
+            <li><a data-lang="en" href="#">English</a></li>
           </ul>
         </div>
-        <div class="relative dropdown">
-          <button class="dropdown-toggle flex items-center gap-1 px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" id="btnCurrency"><i class="bi bi-currency-exchange"></i> <span id="lblCurrency">EUR</span></button>
-          <ul class="dropdown-menu absolute right-0 mt-1 hidden bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-md" id="menuCurrency">
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-cur="EUR" href="#">EUR €</a></li>
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-cur="USD" href="#">USD $</a></li>
+        <div class="dropdown">
+          <button class="dropdown-toggle btn btn-outline-primary" id="btnCurrency"><i class="bi bi-currency-exchange"></i> <span id="lblCurrency">EUR</span></button>
+          <ul class="dropdown-menu" id="menuCurrency">
+            <li><a data-cur="EUR" href="#">EUR €</a></li>
+            <li><a data-cur="USD" href="#">USD $</a></li>
           </ul>
         </div>
-        <button class="px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" id="themeToggle" aria-label="Tema"><i class="bi bi-moon" id="themeIcon"></i></button>
+        <button class="btn btn-outline-primary" id="themeToggle" aria-label="Tema"><i class="bi bi-moon" id="themeIcon"></i></button>
         <?php if ($isLogged): ?>
-          <a class="px-3 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition" href="/panel.php">Panel</a>
-          <a class="px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" href="/logout.php">Salir</a>
+          <a class="btn btn-primary" href="/panel.php">Panel</a>
+          <a class="btn btn-outline-primary" href="/logout.php">Salir</a>
         <?php else: ?>
-          <a class="px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" href="/login.php">Login</a>
-          <a class="px-3 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition" href="/register.php">Registro</a>
+          <a class="btn btn-outline-primary" href="/login.php">Login</a>
+          <a class="btn btn-primary" href="/register.php">Registro</a>
         <?php endif; ?>
       </div>
     </div>
   </div>
 </nav>
+

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -29,15 +29,22 @@ body {
 .navbar { display:flex; align-items:center; justify-content:space-between; padding:.5rem 1rem; background:var(--body-bg); }
 .navbar-brand { display:flex; align-items:center; gap:.5rem; font-weight:600; color:var(--color-primary); text-decoration:none; }
 .navbar-toggler { background:none; border:0; font-size:1.5rem; cursor:pointer; }
-.navbar-menu { display:none; align-items:center; gap:1rem; }
+.navbar-menu { display:none; flex-direction:column; align-items:center; gap:1rem; }
 .navbar-menu.open { display:flex; }
-.navbar-nav { display:flex; gap:1rem; list-style:none; margin:0; padding:0; }
+.navbar-nav { display:flex; flex-direction:column; gap:1rem; list-style:none; margin:0; padding:0; }
 .nav-link { text-decoration:none; color:inherit; transition:color .2s ease; }
 .nav-link:hover { color:var(--color-primary); }
-.nav-actions { display:flex; align-items:center; gap:.5rem; }
+.nav-actions { display:flex; align-items:center; gap:.5rem; margin-top:.5rem; }
+.dropdown { position:relative; }
+.dropdown-menu { position:absolute; right:0; margin-top:.25rem; background:var(--body-bg); border:1px solid #ddd; border-radius:.375rem; min-width:6rem; box-shadow:0 .25rem .5rem rgba(0,0,0,.15); display:none; z-index:1000; }
+.dropdown-menu.show { display:block; }
+.dropdown-menu a { display:block; padding:.25rem .75rem; text-decoration:none; color:inherit; }
+.dropdown-menu a:hover { background:var(--color-primary); color:#fff; }
 
 @media(min-width:768px){
-  .navbar-menu{display:flex !important;}
+  .navbar-menu{display:flex !important; flex-direction:row;}
+  .navbar-nav{flex-direction:row;}
+  .nav-actions{margin-top:0;}
   #navToggle{display:none;}
 }
 
@@ -59,10 +66,14 @@ body {
 .col-md-6 { flex:0 0 100%; }
 .col-md-4 { flex:0 0 100%; }
 .col-md-3 { flex:0 0 100%; }
+.justify-content-md-start { justify-content:center; }
+.text-md-start { text-align:center; }
 @media(min-width:768px){
   .col-md-6{flex:0 0 50%;}
   .col-md-4{flex:0 0 33.333%;}
   .col-md-3{flex:0 0 25%;}
+  .justify-content-md-start{justify-content:flex-start;}
+  .text-md-start{text-align:left;}
 }
 .d-flex { display:flex; }
 .align-items-center { align-items:center; }
@@ -74,6 +85,7 @@ body {
 .mt-4 { margin-top:1.5rem; }
 .mb-4 { margin-bottom:1.5rem; }
 .py-5 { padding-top:3rem; padding-bottom:3rem; }
+.p-4 { padding:1rem; }
 .h3 { font-size:1.75rem; }
 .h4 { font-size:1.5rem; }
 
@@ -89,10 +101,14 @@ body {
 .trustbar img { height:24px; }
 
 .text-center { text-align:center; }
+.text-light { color:#fff; }
+.text-dark { color:#000; }
 .text-muted { color:#6c757d; }
 .badge { display:inline-block; padding:.25rem .5rem; border-radius:.25rem; font-size:.75rem; }
 .bg-secondary { background:#6c757d; color:#fff; }
 .bg-light { background:#f8f9fa; color:#000; }
+.bg-gray-400 { background:#9ca3af; }
+.shadow { box-shadow:0 .5rem 1rem rgba(0,0,0,.15); }
 .shadow-sm { box-shadow:0 .125rem .25rem rgba(0,0,0,.075); }
 .bg-body-secondary { background:#e9ecef; }
 [data-theme="dark"] .bg-body-secondary { background:#1f1f23; }

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -20,7 +20,7 @@
   const navToggle = document.getElementById('navToggle');
   const mainNav = document.getElementById('mainNav');
   navToggle?.addEventListener('click', () => {
-    mainNav?.classList.toggle('hidden');
+    mainNav?.classList.toggle('open');
   });
 
   // Dropdowns
@@ -28,12 +28,12 @@
     btn.addEventListener('click', e => {
       e.preventDefault();
       const menu = btn.nextElementSibling;
-      menu?.classList.toggle('hidden');
+      menu?.classList.toggle('show');
     });
   });
   document.addEventListener('click', e => {
     if (!e.target.closest('.dropdown')) {
-      document.querySelectorAll('.dropdown-menu:not(.hidden)').forEach(m => m.classList.add('hidden'));
+      document.querySelectorAll('.dropdown-menu.show').forEach(m => m.classList.remove('show'));
     }
   });
 

--- a/tests/security_test.php
+++ b/tests/security_test.php
@@ -1,27 +1,42 @@
 <?php
 declare(strict_types=1);
+
 require_once __DIR__.'/../init.php';
 require_once __DIR__.'/../helpers.php';
 
-// insert test user
 $db = db();
-$db->exec("INSERT INTO users (username, role) VALUES ('tester', 'admin')");
-$u = $db->query("SELECT * FROM users WHERE username='tester'")->fetch();
+$db->prepare('DELETE FROM rate_limits WHERE key=?')->execute(['login']);
 
-assert(user_has_role($u, 'admin') === true);
-assert(user_has_role($u, 'user') === false);
-require_role($u, 'admin');
+function create_test_user(PDO $db): array {
+  $db->prepare('DELETE FROM users WHERE username=?')->execute(['tester']);
+  $st = $db->prepare('INSERT INTO users (username, role) VALUES (?, ?)');
+  $st->execute(['tester', 'admin']);
+  return $db->query("SELECT * FROM users WHERE username='tester'")->fetch();
+}
 
-// audit logging
-audit((int)$u['id'], 'test', ['ok'=>1]);
-$log = $db->query('SELECT * FROM audit_logs')->fetch();
-assert($log['action'] === 'test');
-assert(strlen($log['signature']) === 64);
+function cleanup(PDO $db, int $uid): void {
+  // audit logs are append-only, so we only remove rate limit and user entries
+  $db->prepare('DELETE FROM rate_limits WHERE key=?')->execute(['login']);
+  $db->prepare('DELETE FROM users WHERE id=?')->execute([$uid]);
+}
 
-// rate limiting
-assert(rate_limit('login', 2, 60) === true);
-assert(rate_limit('login', 2, 60) === true);
-assert(rate_limit('login', 2, 60) === false);
+$user = create_test_user($db);
 
+assert(user_has_role($user, 'admin') === true, 'Admin role must be present');
+assert(user_has_role($user, 'user') === false, 'User role should not be present');
+require_role($user, 'admin');
+
+$auditId = audit((int)$user['id'], 'test', ['ok' => 1]);
+$st = $db->prepare('SELECT * FROM audit_logs WHERE id=?');
+$st->execute([$auditId]);
+$log = $st->fetch();
+assert($log['action'] === 'test', 'Audit action mismatch');
+assert(strlen($log['signature']) === 64, 'Audit signature length mismatch');
+
+assert(rate_limit('login', 2, 60) === true, 'First attempt should pass');
+assert(rate_limit('login', 2, 60) === true, 'Second attempt should pass');
+assert(rate_limit('login', 2, 60) === false, 'Third attempt should be limited');
+
+cleanup($db, (int)$user['id']);
 echo "OK\n";
 


### PR DESCRIPTION
## Summary
- Return inserted ID from `audit` helper for precise log retrieval
- Refactor security test with setup/cleanup helpers and rate limit reset
- Drop Tailwind, add custom navigation and badges for the homepage

## Testing
- `php -d assert.exception=1 tests/security_test.php`
- `php -d assert.exception=1 tests/mail_test.php`
- `php -d assert.exception=1 tests/privacy_test.php`
- `php -d assert.exception=1 tests/stripe_webhook_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68add2d7cc0c8333873d34b0135315d9