### PR TITLE
Refactor security test and adopt Bootstrap styling

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -33,13 +33,14 @@ function require_role(array $u, string ...$roles): void {
   }
 }
 
-function audit(int $uid, string $action, array $payload = []): void {
+function audit(int $uid, string $action, array $payload = []): int {
   global $CONFIG;
   $meta = json_encode($payload, JSON_UNESCAPED_UNICODE);
   $ts = time();
   $sig = hash_hmac('sha256', $uid . '|' . $action . '|' . $meta . '|' . $ts, $CONFIG['AUDIT_SECRET']);
   $st = db()->prepare('INSERT INTO audit_logs(user_id,action,meta,signature,created_at) VALUES(?,?,?,?,datetime("now"))');
   $st->execute([$uid, $action, $meta, $sig]);
+  return (int)db()->lastInsertId();
 }
 
 function rate_limit(string $key, int $limit, int $period): bool {

--- a/index.php
+++ b/index.php
@@ -15,10 +15,10 @@ include __DIR__.'/partials/head.php';
       <div class="col-md-6 text-md-start">
         <h1 class="display-5 fw-bold" data-i18n="hero.title">Privacidad simple. Rendimiento constante.</h1>
         <p class="lead" data-i18n="hero.subtitle">VPN WireGuard, Bitwarden autoalojado y nube cifrada con servidores en Reino Unido y Alemania.</p>
-        <div class="d-flex gap-2 justify-content-center justify-content-md-start">
+        <div class="d-flex gap-2 justify-content-center justify-content-md-start align-items-center">
           <button class="btn btn-primary" onclick="document.querySelector('#services').scrollIntoView({behavior:'smooth'})" data-i18n="hero.cta_primary">Ver servicios</button>
           <button class="btn btn-outline-light" onclick="document.querySelector('#pricing').scrollIntoView({behavior:'smooth'})" data-i18n="hero.cta_secondary">Ver precios</button>
-          <span class="px-2 py-1 text-sm rounded bg-gray-100 text-gray-900 self-center">Desde <span class="price price-badge" data-price="PRICE_VPN"></span><span class="unit"></span> / mes</span>
+          <span class="badge bg-light text-dark">Desde <span class="price price-badge" data-price="PRICE_VPN"></span><span class="unit"></span> / mes</span>
         </div>
         <div class="d-flex gap-2 mt-3">
           <i class="bi bi-shield-lock"></i><strong>&nbsp;Cifrado serio</strong>
@@ -32,7 +32,7 @@ include __DIR__.'/partials/head.php';
         </div>
       </div>
       <div class="col-md-6 mt-4 mt-md-0">
-        <div class="card text-body shadow">
+        <div class="card shadow">
           <div class="card-body">
             <div class="d-flex justify-content-between">
               <strong>Estado</strong><span class="text-muted">Infra UE</span>
@@ -78,7 +78,7 @@ include __DIR__.'/partials/head.php';
             <img class="service-logo logo-dark" src="static/rsc/nnm-vpn-logo.png" alt="VPN">
             <div class="d-flex justify-content-between">
               <strong data-i18n="sections.services.card_vpn.title">VPN</strong>
-              <span class="px-2 py-1 text-xs rounded bg-gray-600 text-white"><span class="price" data-price="PRICE_VPN"></span><span class="unit"></span> /m</span>
+              <span class="badge bg-secondary"><span class="price" data-price="PRICE_VPN"></span><span class="unit"></span> /m</span>
             </div>
             <ul class="text-muted">
               <li data-i18n="sections.services.card_vpn.p1">WireGuard por defecto.</li>
@@ -93,7 +93,7 @@ include __DIR__.'/partials/head.php';
             <img class="service-logo logo-dark" src="static/rsc/nnm-psw-logo.png" alt="Gestor">
             <div class="d-flex justify-content-between">
               <strong data-i18n="sections.services.card_password_manager.title">Gestor de contraseñas</strong>
-              <span class="px-2 py-1 text-xs rounded bg-gray-600 text-white"><span class="price" data-price="PRICE_PASSWORD"></span><span class="unit"></span> /m</span>
+              <span class="badge bg-secondary"><span class="price" data-price="PRICE_PASSWORD"></span><span class="unit"></span> /m</span>
             </div>
             <ul class="text-muted">
               <li data-i18n="sections.services.card_password_manager.p1">Cifrado E2E.</li>
@@ -108,7 +108,7 @@ include __DIR__.'/partials/head.php';
             <img class="service-logo logo-dark" src="static/rsc/nnm-stg-logo.png" alt="Storage">
             <div class="d-flex justify-content-between">
               <strong data-i18n="sections.services.card_encrypted_storage.title">Almacenamiento cifrado</strong>
-              <span class="px-2 py-1 text-xs rounded bg-gray-600 text-white"><span class="price" data-price="PRICE_STORAGE"></span><span class="unit"></span> /m</span>
+              <span class="badge bg-secondary"><span class="price" data-price="PRICE_STORAGE"></span><span class="unit"></span> /m</span>
             </div>
             <ul class="text-muted">
               <li data-i18n="sections.services.card_encrypted_storage.p1">Versionado y enlaces protegidos.</li>

--- a/partials/footer.php
+++ b/partials/footer.php
@@ -1,3 +1,4 @@
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-q2JyCgUloEwuBsBtWDyt41FrV6eI2GJrivF/yMn2f60rocOc8+An0MhN8E0yGpGd" crossorigin="anonymous"></script>
 <script src="/static/js/nav.js"></script>
 <script src="/static/js/i18n.js"></script>
 <script src="/static/js/currency.js"></script>

--- a/partials/head.php
+++ b/partials/head.php
@@ -9,7 +9,7 @@ $host = $_SERVER['HTTP_HOST'] ?? 'nnm.example';
 $canonical = $canonical ?? ('https://' . $host . ($_SERVER['REQUEST_URI'] ?? '/'));
 ?>
 <!doctype html>
-<html lang="<?= e($lang) ?>" data-theme="light">
+<html lang="<?= e($lang) ?>" data-bs-theme="light">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -20,8 +20,8 @@ $canonical = $canonical ?? ('https://' . $host . ($_SERVER['REQUEST_URI'] ?? '/'
   <title><?= e($title) ?></title>
   <meta name="color-scheme" content="light dark">
   <link rel="icon" href="/static/rsc/nnm-logo.ico">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-wXrF8b1Gj2n4nHNNMTvEihQ/HUkNzxaz2YsR0vuX+cl2Dx+Bm3Xw1K7arxIM+JhK" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/static/css/styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 </head>

--- a/partials/nav.php
+++ b/partials/nav.php
@@ -1,45 +1,46 @@
 <?php $isLogged = !empty($_SESSION['uid']); ?>
-<nav class="bg-white dark:bg-gray-900 shadow-sm">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between h-16">
-    <a class="flex items-center gap-2 font-semibold text-indigo-600 dark:text-indigo-400" href="/">
-      <img src="/static/rsc/nnm-logo.png" alt="NNM" class="w-7 h-7 logo-dark">
+<nav class="navbar navbar-expand-md shadow-sm bg-body">
+  <div class="container">
+    <a class="navbar-brand" href="/">
+      <img src="/static/rsc/nnm-logo.png" alt="NNM" class="logo-dark">
       <span data-i18n="brand">NNM Secure</span>
     </a>
-    <button class="md:hidden text-2xl" id="navToggle" aria-label="Menú">
-      <i class="bi bi-list"></i>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Menú">
+      <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="hidden flex flex-col md:flex md:flex-row md:items-center md:space-x-6" id="mainNav">
-      <ul class="flex flex-col md:flex-row md:space-x-4">
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#services" data-i18n="nav.services">Servicios</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#features" data-i18n="nav.features">Características</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#pricing" data-i18n="nav.pricing">Precios</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#faq" data-i18n="nav.faq">FAQ</a></li>
-        <li><a class="block py-2 md:py-0 hover:text-indigo-600" href="/#contact" data-i18n="nav.contact">Contacto</a></li>
+    <div class="collapse navbar-collapse" id="mainNav">
+      <ul class="navbar-nav me-auto mb-2 mb-md-0">
+        <li class="nav-item"><a class="nav-link" href="/#services" data-i18n="nav.services">Servicios</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#features" data-i18n="nav.features">Características</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#pricing" data-i18n="nav.pricing">Precios</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#faq" data-i18n="nav.faq">FAQ</a></li>
+        <li class="nav-item"><a class="nav-link" href="/#contact" data-i18n="nav.contact">Contacto</a></li>
       </ul>
-      <div class="flex items-center space-x-2 mt-2 md:mt-0">
-        <div class="relative dropdown">
-          <button class="dropdown-toggle flex items-center gap-1 px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" id="btnLang"><i class="bi bi-translate"></i> <span id="lblLang">ES</span></button>
-          <ul class="dropdown-menu absolute right-0 mt-1 hidden bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-md" id="menuLang">
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-lang="es" href="#">Español</a></li>
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-lang="en" href="#">English</a></li>
+      <div class="d-flex align-items-center gap-2">
+        <div class="dropdown">
+          <button class="btn btn-outline-primary dropdown-toggle" id="btnLang" data-bs-toggle="dropdown"><i class="bi bi-translate"></i> <span id="lblLang">ES</span></button>
+          <ul class="dropdown-menu dropdown-menu-end" id="menuLang">
+            <li><a class="dropdown-item" data-lang="es" href="#">Español</a></li>
+            <li><a class="dropdown-item" data-lang="en" href="#">English</a></li>
           </ul>
         </div>
-        <div class="relative dropdown">
-          <button class="dropdown-toggle flex items-center gap-1 px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" id="btnCurrency"><i class="bi bi-currency-exchange"></i> <span id="lblCurrency">EUR</span></button>
-          <ul class="dropdown-menu absolute right-0 mt-1 hidden bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-md" id="menuCurrency">
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-cur="EUR" href="#">EUR €</a></li>
-            <li><a class="block px-3 py-1 hover:bg-indigo-600 hover:text-white" data-cur="USD" href="#">USD $</a></li>
+        <div class="dropdown">
+          <button class="btn btn-outline-primary dropdown-toggle" id="btnCurrency" data-bs-toggle="dropdown"><i class="bi bi-currency-exchange"></i> <span id="lblCurrency">EUR</span></button>
+          <ul class="dropdown-menu dropdown-menu-end" id="menuCurrency">
+            <li><a class="dropdown-item" data-cur="EUR" href="#">EUR €</a></li>
+            <li><a class="dropdown-item" data-cur="USD" href="#">USD $</a></li>
           </ul>
         </div>
-        <button class="px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" id="themeToggle" aria-label="Tema"><i class="bi bi-moon" id="themeIcon"></i></button>
+        <button class="btn btn-outline-primary" id="themeToggle" aria-label="Tema"><i class="bi bi-moon" id="themeIcon"></i></button>
         <?php if ($isLogged): ?>
-          <a class="px-3 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition" href="/panel.php">Panel</a>
-          <a class="px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" href="/logout.php">Salir</a>
+          <a class="btn btn-primary" href="/panel.php">Panel</a>
+          <a class="btn btn-outline-primary" href="/logout.php">Salir</a>
         <?php else: ?>
-          <a class="px-3 py-2 rounded border border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white transition" href="/login.php">Login</a>
-          <a class="px-3 py-2 rounded bg-indigo-600 text-white hover:bg-indigo-700 transition" href="/register.php">Registro</a>
+          <a class="btn btn-outline-primary" href="/login.php">Login</a>
+          <a class="btn btn-primary" href="/register.php">Registro</a>
         <?php endif; ?>
       </div>
     </div>
   </div>
 </nav>
+

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,114 +1,83 @@
 :root {
-  --brand-primary: #6d4aff;
+  --bs-primary: #6d4aff;
   --brand-secondary: #4a34c4;
-  --brand-success: #2ecc71;
-  --brand-danger: #e74c3c;
-  --brand-bg-light: #f8f8fa;
-  --brand-bg-dark: #0d0d0f;
 }
 
-[data-theme="light"] {
-  --body-bg: var(--brand-bg-light);
-  --body-color: #1b1b1f;
-  --color-primary: var(--brand-primary);
+[data-bs-theme="light"] {
+  --bs-body-bg: #f8f8fa;
+  --bs-body-color: #1b1b1f;
 }
 
-[data-theme="dark"] {
-  --body-bg: var(--brand-bg-dark);
-  --body-color: #f8f8fa;
-  --color-primary: var(--brand-primary);
+[data-bs-theme="dark"] {
+  --bs-body-bg: #0d0d0f;
+  --bs-body-color: #f8f8fa;
 }
 
 body {
   font-family: Inter, system-ui, sans-serif;
-  background: var(--body-bg);
-  color: var(--body-color);
 }
 
-/* Nav */
-.navbar { display:flex; align-items:center; justify-content:space-between; padding:.5rem 1rem; background:var(--body-bg); }
-.navbar-brand { display:flex; align-items:center; gap:.5rem; font-weight:600; color:var(--color-primary); text-decoration:none; }
-.navbar-toggler { background:none; border:0; font-size:1.5rem; cursor:pointer; }
-.navbar-menu { display:none; align-items:center; gap:1rem; }
-.navbar-menu.open { display:flex; }
-.navbar-nav { display:flex; gap:1rem; list-style:none; margin:0; padding:0; }
-.nav-link { text-decoration:none; color:inherit; transition:color .2s ease; }
-.nav-link:hover { color:var(--color-primary); }
-.nav-actions { display:flex; align-items:center; gap:.5rem; }
-
-@media(min-width:768px){
-  .navbar-menu{display:flex !important;}
-  #navToggle{display:none;}
+.bg-brand {
+  background: linear-gradient(135deg, var(--bs-primary), var(--brand-secondary));
 }
 
-/* Buttons */
-.btn { cursor:pointer; border-radius:.375rem; padding:.45rem .9rem; font-weight:500; transition:background .3s, color .3s, transform .15s; border:2px solid transparent; background:var(--color-primary); color:#fff; }
-.btn:hover { transform:translateY(-2px); }
-.btn-primary { background:var(--color-primary); }
-.btn-primary:hover { background:var(--brand-secondary); }
-.btn-outline-primary { background:transparent; color:var(--color-primary); border-color:var(--color-primary); }
-.btn-outline-primary:hover { background:var(--color-primary); color:#fff; }
-.btn-outline-light { background:transparent; color:#fff; border-color:#fff; }
-.btn-outline-light:hover { background:#fff; color:var(--color-primary); }
-
-/* Layout utilities */
-.container { width:min(100%, 1200px); margin:0 auto; padding:0 1rem; }
-.container-fluid { width:100%; padding:0 1rem; }
-.row { display:flex; flex-wrap:wrap; margin:-.5rem; }
-.col-md-6, .col-md-4, .col-md-3, .col { padding:.5rem; }
-.col-md-6 { flex:0 0 100%; }
-.col-md-4 { flex:0 0 100%; }
-.col-md-3 { flex:0 0 100%; }
-@media(min-width:768px){
-  .col-md-6{flex:0 0 50%;}
-  .col-md-4{flex:0 0 33.333%;}
-  .col-md-3{flex:0 0 25%;}
+.status-dot {
+  width: .6rem;
+  height: .6rem;
+  border-radius: 50%;
 }
-.d-flex { display:flex; }
-.align-items-center { align-items:center; }
-.justify-content-between { justify-content:space-between; }
-.justify-content-center { justify-content:center; }
-.gap-2 { gap:.5rem; }
-.gap-4 { gap:1.5rem; }
-.mt-3 { margin-top:1rem; }
-.mt-4 { margin-top:1.5rem; }
-.mb-4 { margin-bottom:1.5rem; }
-.py-5 { padding-top:3rem; padding-bottom:3rem; }
-.h3 { font-size:1.75rem; }
-.h4 { font-size:1.5rem; }
 
-/* Cards and misc */
-.bg-brand { background: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary)); }
-.card { border:none; border-radius:.75rem; background:#fff; }
-[data-theme="dark"] .card { background:#1a1a1e; }
-[data-theme="dark"] .btn-outline-primary { color:var(--color-primary); border-color:var(--color-primary); }
-[data-theme="dark"] .btn-outline-primary:hover { background:var(--color-primary); color:#fff; }
+.service-logo {
+  width: auto;
+  height: 64px;
+  object-fit: contain;
+}
 
-.status-dot { width:.6rem; height:.6rem; border-radius:50%; }
-.service-logo { width:auto; height:64px; object-fit:contain; }
-.trustbar img { height:24px; }
+.trustbar img {
+  height: 24px;
+}
 
-.text-center { text-align:center; }
-.text-muted { color:#6c757d; }
-.badge { display:inline-block; padding:.25rem .5rem; border-radius:.25rem; font-size:.75rem; }
-.bg-secondary { background:#6c757d; color:#fff; }
-.bg-light { background:#f8f9fa; color:#000; }
-.shadow-sm { box-shadow:0 .125rem .25rem rgba(0,0,0,.075); }
-.bg-body-secondary { background:#e9ecef; }
-[data-theme="dark"] .bg-body-secondary { background:#1f1f23; }
-.display-5 { font-size:2.5rem; }
-.fw-bold { font-weight:700; }
-.lead { font-size:1.25rem; }
+.fade-in {
+  opacity: 0;
+  animation: fadeIn .6s ease forwards;
+}
 
-.fade-in { opacity:0; animation:fadeIn .6s ease forwards; }
-@keyframes fadeIn { from {opacity:0; transform:translateY(10px);} to {opacity:1; transform:translateY(0);} }
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
-.loader { position:fixed; inset:0; background:var(--body-bg); display:flex; align-items:center; justify-content:center; z-index:2000; transition:opacity .3s ease; }
-.loader.hide { opacity:0; pointer-events:none; }
-.loader img { width:64px; height:64px; animation:spin 1.2s linear infinite; }
-@keyframes spin { to {transform: rotate(360deg);} }
+.loader {
+  position: fixed;
+  inset: 0;
+  background: var(--bs-body-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+  transition: opacity .3s ease;
+}
 
-/* Logos modo oscuro */
-.logo-dark { transition:filter .3s ease; }
-[data-theme="dark"] .logo-dark { filter:brightness(0) invert(1); }
+.loader.hide {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loader img {
+  width: 64px;
+  height: 64px;
+  animation: spin 1.2s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.logo-dark {
+  transition: filter .3s ease;
+}
+
+[data-bs-theme="dark"] .logo-dark {
+  filter: brightness(0) invert(1);
+}
 

--- a/static/js/nav.js
+++ b/static/js/nav.js
@@ -1,10 +1,10 @@
-// nav.js — manejo de menú, tema, idioma y moneda sin Bootstrap
+// nav.js — tema, idioma y moneda con Bootstrap
 (() => {
   const root = document.documentElement;
   const themeKey = 'nnm_theme';
 
   function applyTheme(mode){
-    root.setAttribute('data-theme', mode);
+    root.setAttribute('data-bs-theme', mode);
     const icon = document.getElementById('themeIcon');
     if(icon) icon.className = mode === 'dark' ? 'bi bi-sun' : 'bi bi-moon';
     localStorage.setItem(themeKey, mode);
@@ -13,28 +13,7 @@
   applyTheme(localStorage.getItem(themeKey) || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'));
 
   document.getElementById('themeToggle')?.addEventListener('click', () => {
-    applyTheme(root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
-  });
-
-  // Menú responsive
-  const navToggle = document.getElementById('navToggle');
-  const mainNav = document.getElementById('mainNav');
-  navToggle?.addEventListener('click', () => {
-    mainNav?.classList.toggle('hidden');
-  });
-
-  // Dropdowns
-  document.querySelectorAll('.dropdown-toggle').forEach(btn => {
-    btn.addEventListener('click', e => {
-      e.preventDefault();
-      const menu = btn.nextElementSibling;
-      menu?.classList.toggle('hidden');
-    });
-  });
-  document.addEventListener('click', e => {
-    if (!e.target.closest('.dropdown')) {
-      document.querySelectorAll('.dropdown-menu:not(.hidden)').forEach(m => m.classList.add('hidden'));
-    }
+    applyTheme(root.getAttribute('data-bs-theme') === 'dark' ? 'light' : 'dark');
   });
 
   // Idioma

--- a/tests/security_test.php
+++ b/tests/security_test.php
@@ -1,27 +1,42 @@
 <?php
 declare(strict_types=1);
+
 require_once __DIR__.'/../init.php';
 require_once __DIR__.'/../helpers.php';
 
-// insert test user
 $db = db();
-$db->exec("INSERT INTO users (username, role) VALUES ('tester', 'admin')");
-$u = $db->query("SELECT * FROM users WHERE username='tester'")->fetch();
+$db->prepare('DELETE FROM rate_limits WHERE key=?')->execute(['login']);
 
-assert(user_has_role($u, 'admin') === true);
-assert(user_has_role($u, 'user') === false);
-require_role($u, 'admin');
+function create_test_user(PDO $db): array {
+  $db->prepare('DELETE FROM users WHERE username=?')->execute(['tester']);
+  $st = $db->prepare('INSERT INTO users (username, role) VALUES (?, ?)');
+  $st->execute(['tester', 'admin']);
+  return $db->query("SELECT * FROM users WHERE username='tester'")->fetch();
+}
 
-// audit logging
-audit((int)$u['id'], 'test', ['ok'=>1]);
-$log = $db->query('SELECT * FROM audit_logs')->fetch();
-assert($log['action'] === 'test');
-assert(strlen($log['signature']) === 64);
+function cleanup(PDO $db, int $uid): void {
+  // audit logs are append-only, so we only remove rate limit and user entries
+  $db->prepare('DELETE FROM rate_limits WHERE key=?')->execute(['login']);
+  $db->prepare('DELETE FROM users WHERE id=?')->execute([$uid]);
+}
 
-// rate limiting
-assert(rate_limit('login', 2, 60) === true);
-assert(rate_limit('login', 2, 60) === true);
-assert(rate_limit('login', 2, 60) === false);
+$user = create_test_user($db);
 
+assert(user_has_role($user, 'admin') === true, 'Admin role must be present');
+assert(user_has_role($user, 'user') === false, 'User role should not be present');
+require_role($user, 'admin');
+
+$auditId = audit((int)$user['id'], 'test', ['ok' => 1]);
+$st = $db->prepare('SELECT * FROM audit_logs WHERE id=?');
+$st->execute([$auditId]);
+$log = $st->fetch();
+assert($log['action'] === 'test', 'Audit action mismatch');
+assert(strlen($log['signature']) === 64, 'Audit signature length mismatch');
+
+assert(rate_limit('login', 2, 60) === true, 'First attempt should pass');
+assert(rate_limit('login', 2, 60) === true, 'Second attempt should pass');
+assert(rate_limit('login', 2, 60) === false, 'Third attempt should be limited');
+
+cleanup($db, (int)$user['id']);
 echo "OK\n";
 


### PR DESCRIPTION
## Summary
- Return inserted ID from `audit` helper for precise log retrieval
- Refactor security test with setup/cleanup helpers and rate limit reset
- Integrate Bootstrap for layout and theming; rebuild navbar and slim custom CSS/JS

## Testing
- `php -d assert.exception=1 tests/security_test.php`
- `php -d assert.exception=1 tests/mail_test.php`
- `php -d assert.exception=1 tests/privacy_test.php`
- `php -d assert.exception=1 tests/stripe_webhook_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68add2d7cc0c8333873d34b0135315d9